### PR TITLE
Use global viper in `actions` subcommands

### DIFF
--- a/cli/commands/actions.go
+++ b/cli/commands/actions.go
@@ -44,9 +44,6 @@ func NewActionsCmd(ec *cli.ExecutionContext) *cobra.Command {
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string){
-			ec.Logger.Debug(ec.Config.Endpoint)
-		},
 	}
 
 	actionsCmd.AddCommand(

--- a/cli/commands/actions.go
+++ b/cli/commands/actions.go
@@ -44,12 +44,26 @@ func NewActionsCmd(ec *cli.ExecutionContext) *cobra.Command {
 			}
 			return nil
 		},
+		Run: func(cmd *cobra.Command, args []string){
+			ec.Logger.Debug(ec.Config.Endpoint)
+		},
 	}
+
 	actionsCmd.AddCommand(
 		newActionsCreateCmd(ec),
 		newActionsCodegenCmd(ec),
 		newActionsUseCodegenCmd(ec),
 	)
+
+	actionsCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	actionsCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	actionsCmd.PersistentFlags().String("access-key", "", "access key for Hasura GraphQL Engine")
+	actionsCmd.PersistentFlags().MarkDeprecated("access-key", "use --admin-secret instead")
+
+	v.BindPFlag("endpoint", actionsCmd.PersistentFlags().Lookup("endpoint"))
+	v.BindPFlag("admin_secret", actionsCmd.PersistentFlags().Lookup("admin-secret"))
+	v.BindPFlag("access_key", actionsCmd.PersistentFlags().Lookup("access-key"))
+
 	return actionsCmd
 }
 

--- a/cli/commands/actions.go
+++ b/cli/commands/actions.go
@@ -47,7 +47,7 @@ func NewActionsCmd(ec *cli.ExecutionContext) *cobra.Command {
 	}
 
 	actionsCmd.AddCommand(
-		newActionsCreateCmd(ec),
+		newActionsCreateCmd(ec, v),
 		newActionsCodegenCmd(ec),
 		newActionsUseCodegenCmd(ec),
 	)

--- a/cli/commands/actions_codegen.go
+++ b/cli/commands/actions_codegen.go
@@ -30,9 +30,6 @@ func newActionsCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Derive an action from a hasura operation
   hasura actions codegen [action-name] --derive-from ""`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.actions = args
 			return opts.run()

--- a/cli/commands/actions_codegen.go
+++ b/cli/commands/actions_codegen.go
@@ -9,11 +9,9 @@ import (
 	"github.com/hasura/graphql-engine/cli/metadata/actions/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newActionsCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.GetViper()
 	opts := &actionsCodegenOptions{
 		EC: ec,
 	}
@@ -33,7 +31,6 @@ func newActionsCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura actions codegen [action-name] --derive-from ""`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -44,17 +41,6 @@ func newActionsCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f := actionsCodegenCmd.Flags()
 
 	f.StringVar(&opts.deriveFrom, "derive-from", "", "derive action from a hasura operation")
-
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
-
 	return actionsCodegenCmd
 }
 

--- a/cli/commands/actions_create.go
+++ b/cli/commands/actions_create.go
@@ -34,10 +34,6 @@ func newActionsCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura actions create [action-name] --kind synchronous --webhook http://localhost:3000`,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.run()
@@ -48,18 +44,10 @@ func newActionsCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 	f.StringVar(&opts.deriveFrom, "derive-from", "", "derive action from a Hasura operation")
 	f.BoolVar(&opts.withCodegen, "with-codegen", false, "create action along with codegen")
-
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
 	f.String("kind", "", "kind to use in action")
 	f.String("webhook", "", "webhook to use in action")
 
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
+	// bind to viper
 	v.BindPFlag("actions.kind", f.Lookup("kind"))
 	v.BindPFlag("actions.handler_webhook_baseurl", f.Lookup("webhook"))
 

--- a/cli/commands/actions_create.go
+++ b/cli/commands/actions_create.go
@@ -13,8 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func newActionsCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.GetViper()
+func newActionsCreateCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
 	opts := &actionsCreateOptions{
 		EC: ec,
 	}

--- a/cli/commands/actions_use_codegen.go
+++ b/cli/commands/actions_use_codegen.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 type codegenFramework struct {
@@ -19,7 +18,6 @@ type codegenFramework struct {
 }
 
 func newActionsUseCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.GetViper()
 	opts := &actionsUseCodegenOptions{
 		EC: ec,
 	}
@@ -38,10 +36,6 @@ func newActionsUseCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Use a codegen with a starter kit
   hasura actions use-codegen --with-starter-kit true`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.run()
 		},
@@ -52,16 +46,6 @@ func newActionsUseCodegenCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.StringVar(&opts.framework, "framework", "", "framework to be used by codegen")
 	f.StringVar(&opts.outputDir, "output-dir", "", "directory to create the codegen files")
 	f.BoolVar(&opts.withStarterKit, "with-starter-kit", false, "clone starter kit for a framework")
-
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return actionsUseCodegenCmd
 }

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -13,9 +13,16 @@ func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
 	ec.Viper = v
 	metadataCmd := &cobra.Command{
-		Use:          "metadata",
-		Aliases:      []string{"md"},
-		Short:        "Manage Hasura GraphQL Engine metadata saved in the database",
+		Use:     "metadata",
+		Aliases: []string{"md"},
+		Short:   "Manage Hasura GraphQL Engine metadata saved in the database",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			err := ec.Prepare()
+			if err != nil {
+				return err
+			}
+			return ec.Validate()
+		},
 		SilenceUsage: true,
 	}
 	metadataCmd.AddCommand(

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -5,10 +5,12 @@ import (
 	"github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // NewMetadataCmd returns the metadata command
 func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.GetViper()
 	metadataCmd := &cobra.Command{
 		Use:          "metadata",
 		Aliases:      []string{"md"},
@@ -23,6 +25,16 @@ func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newMetadataApplyCmd(ec),
 		newMetadataInconsistencyCmd(ec),
 	)
+
+	metadataCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	metadataCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	metadataCmd.PersistentFlags().String("access-key", "", "access key for Hasura GraphQL Engine")
+	metadataCmd.PersistentFlags().MarkDeprecated("access-key", "use --admin-secret instead")
+
+	v.BindPFlag("endpoint", metadataCmd.PersistentFlags().Lookup("endpoint"))
+	v.BindPFlag("admin_secret", metadataCmd.PersistentFlags().Lookup("admin-secret"))
+	v.BindPFlag("access_key", metadataCmd.PersistentFlags().Lookup("access-key"))
+
 	return metadataCmd
 }
 

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -10,7 +10,8 @@ import (
 
 // NewMetadataCmd returns the metadata command
 func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.GetViper()
+	v := viper.New()
+	ec.Viper = v
 	metadataCmd := &cobra.Command{
 		Use:          "metadata",
 		Aliases:      []string{"md"},

--- a/cli/commands/metadata_apply.go
+++ b/cli/commands/metadata_apply.go
@@ -26,13 +26,6 @@ func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Apply metadata to an instance specified by the flag:
   hasura metadata apply --endpoint "<endpoint>"`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.dryRun {
 				o := &MetadataDiffOptions{
@@ -57,7 +50,6 @@ func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 	f.BoolVar(&opts.FromFile, "from-file", false, "apply metadata from migrations/metadata.[yaml|json]")
 	f.BoolVar(&opts.dryRun, "dry-run", false, "show a diff instead of applying the metadata")
-
 
 	return metadataApplyCmd
 }

--- a/cli/commands/metadata_apply.go
+++ b/cli/commands/metadata_apply.go
@@ -6,11 +6,9 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &MetadataApplyOptions{
 		EC:         ec,
 		ActionType: "apply",
@@ -29,7 +27,6 @@ func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura metadata apply --endpoint "<endpoint>"`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -57,18 +54,10 @@ func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 	}
 
 	f := metadataApplyCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
 
 	f.BoolVar(&opts.FromFile, "from-file", false, "apply metadata from migrations/metadata.[yaml|json]")
 	f.BoolVar(&opts.dryRun, "dry-run", false, "show a diff instead of applying the metadata")
 
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataApplyCmd
 }

--- a/cli/commands/metadata_clear.go
+++ b/cli/commands/metadata_clear.go
@@ -50,17 +50,6 @@ func newMetadataClearCmd(ec *cli.ExecutionContext) *cobra.Command {
 		},
 	}
 
-	f := metadataResetCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
-
 	return metadataResetCmd
 }
 

--- a/cli/commands/metadata_clear.go
+++ b/cli/commands/metadata_clear.go
@@ -4,11 +4,9 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMetadataClearCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &MetadataClearOptions{
 		EC:         ec,
 		ActionType: "clear",
@@ -27,14 +25,6 @@ func newMetadataClearCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Clear metadata on a different Hasura instance:
   hasura metadata clear --endpoint "<endpoint>"`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.CalledAs() == "reset" {
 				opts.EC.Logger.Warn("metadata reset command is deprecated, use metadata clear instead")

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mgutz/ansi"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -27,7 +26,6 @@ type MetadataDiffOptions struct {
 }
 
 func newMetadataDiffCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &MetadataDiffOptions{
 		EC:     ec,
 		Output: os.Stdout,
@@ -56,7 +54,6 @@ By default, shows changes between exported metadata file and server metadata.`,
   hasura metadata diff --endpoint "<endpoint>"`,
 		Args: cobra.MaximumNArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -68,17 +65,6 @@ By default, shows changes between exported metadata file and server metadata.`,
 			return opts.Run()
 		},
 	}
-
-	f := metadataDiffCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataDiffCmd
 }

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -53,13 +53,6 @@ By default, shows changes between exported metadata file and server metadata.`,
   # Diff metadata on a different Hasura instance:
   hasura metadata diff --endpoint "<endpoint>"`,
 		Args: cobra.MaximumNArgs(2),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Args = args
 			return opts.Run()

--- a/cli/commands/metadata_export.go
+++ b/cli/commands/metadata_export.go
@@ -4,7 +4,6 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const longHelpMetadataExportCmd = `Export Hasura metadata and save it in migrations/metadata.yaml file.
@@ -14,7 +13,6 @@ permission rules, relationships and event triggers that are defined
 on those tables.`
 
 func newMetadataExportCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &MetadataExportOptions{
 		EC:         ec,
 		ActionType: "export",
@@ -33,7 +31,6 @@ func newMetadataExportCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura metadata export --endpoint "<endpoint>"`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -52,17 +49,6 @@ func newMetadataExportCmd(ec *cli.ExecutionContext) *cobra.Command {
 		},
 		Long: longHelpMetadataExportCmd,
 	}
-
-	f := metadataExportCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataExportCmd
 }

--- a/cli/commands/metadata_export.go
+++ b/cli/commands/metadata_export.go
@@ -30,13 +30,6 @@ func newMetadataExportCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Export metadata to another instance specified by the flag:
   hasura metadata export --endpoint "<endpoint>"`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.EC.Spin("Exporting metadata...")
 			err := opts.Run()

--- a/cli/commands/metadata_inconsistency_drop.go
+++ b/cli/commands/metadata_inconsistency_drop.go
@@ -4,27 +4,16 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMetadataInconsistencyDropCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &metadataInconsistencyDropOptions{
 		EC: ec,
 	}
-
 	metadataInconsistencyDropCmd := &cobra.Command{
 		Use:          "drop",
 		Short:        "Drop inconsistent objects from the metadata",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.EC.Spin("Dropping inconsistent metadata...")
 			err := opts.run()
@@ -36,17 +25,6 @@ func newMetadataInconsistencyDropCmd(ec *cli.ExecutionContext) *cobra.Command {
 			return nil
 		},
 	}
-
-	f := metadataInconsistencyDropCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataInconsistencyDropCmd
 }

--- a/cli/commands/metadata_inconsistency_list.go
+++ b/cli/commands/metadata_inconsistency_list.go
@@ -23,13 +23,6 @@ func newMetadataInconsistencyListCmd(ec *cli.ExecutionContext) *cobra.Command {
 		Aliases:      []string{"ls"},
 		Short:        "List all inconsistent objects from the metadata",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := opts.run()
 			opts.EC.Spinner.Stop()

--- a/cli/commands/metadata_inconsistency_list.go
+++ b/cli/commands/metadata_inconsistency_list.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/migrate/database"
@@ -15,7 +14,6 @@ import (
 )
 
 func newMetadataInconsistencyListCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &metadataInconsistencyListOptions{
 		EC: ec,
 	}
@@ -26,7 +24,6 @@ func newMetadataInconsistencyListCmd(ec *cli.ExecutionContext) *cobra.Command {
 		Short:        "List all inconsistent objects from the metadata",
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -45,17 +42,6 @@ func newMetadataInconsistencyListCmd(ec *cli.ExecutionContext) *cobra.Command {
 			return nil
 		},
 	}
-
-	f := metadataInconsistencyListCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataInconsistencyListCmd
 }

--- a/cli/commands/metadata_inconsistency_status.go
+++ b/cli/commands/metadata_inconsistency_status.go
@@ -15,13 +15,6 @@ func newMetadataInconsistencyStatusCmd(ec *cli.ExecutionContext) *cobra.Command 
 		Use:          "status",
 		Short:        "Check if the metadata is inconsistent or not",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.EC.Spin("reading metadata status...")
 			err := opts.read()

--- a/cli/commands/metadata_inconsistency_status.go
+++ b/cli/commands/metadata_inconsistency_status.go
@@ -4,11 +4,9 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMetadataInconsistencyStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &metadataInconsistencyListOptions{
 		EC: ec,
 	}
@@ -18,7 +16,6 @@ func newMetadataInconsistencyStatusCmd(ec *cli.ExecutionContext) *cobra.Command 
 		Short:        "Check if the metadata is inconsistent or not",
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -40,17 +37,6 @@ func newMetadataInconsistencyStatusCmd(ec *cli.ExecutionContext) *cobra.Command 
 			return nil
 		},
 	}
-
-	f := metadataInconsistencyStatusCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataInconsistencyStatusCmd
 }

--- a/cli/commands/metadata_reload.go
+++ b/cli/commands/metadata_reload.go
@@ -24,13 +24,6 @@ func newMetadataReloadCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Reload metadata on a different instance:
   hasura metadata export --endpoint "<endpoint>"`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.EC.Spin("Reloading metadata...")
 			err := opts.run()

--- a/cli/commands/metadata_reload.go
+++ b/cli/commands/metadata_reload.go
@@ -4,11 +4,9 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMetadataReloadCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &metadataReloadOptions{
 		EC:         ec,
 		actionType: "reload",
@@ -27,7 +25,6 @@ func newMetadataReloadCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura metadata export --endpoint "<endpoint>"`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -45,17 +42,6 @@ func newMetadataReloadCmd(ec *cli.ExecutionContext) *cobra.Command {
 			return nil
 		},
 	}
-
-	f := metadataReloadCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return metadataReloadCmd
 }

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hasura/graphql-engine/cli/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	// Initialize migration drivers
 	_ "github.com/hasura/graphql-engine/cli/migrate/database/hasuradb"
@@ -29,6 +30,7 @@ import (
 
 // NewMigrateCmd returns the migrate command
 func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.GetViper()
 	migrateCmd := &cobra.Command{
 		Use:          "migrate",
 		Short:        "Manage migrations on the database",
@@ -40,6 +42,14 @@ func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newMigrateCreateCmd(ec),
 		newMigrateSquashCmd(ec),
 	)
+	migrateCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	migrateCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	migrateCmd.PersistentFlags().String("access-key", "", "access key for Hasura GraphQL Engine")
+	migrateCmd.PersistentFlags().MarkDeprecated("access-key", "use --admin-secret instead")
+
+	v.BindPFlag("endpoint", migrateCmd.PersistentFlags().Lookup("endpoint"))
+	v.BindPFlag("admin_secret", migrateCmd.PersistentFlags().Lookup("admin-secret"))
+	v.BindPFlag("access_key", migrateCmd.PersistentFlags().Lookup("access-key"))
 	return migrateCmd
 }
 

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -41,11 +41,7 @@ func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = ec.Validate()
-			if err != nil {
-				return err
-			}
-			return nil
+			return ec.Validate()
 		},
 	}
 	migrateCmd.AddCommand(

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -30,17 +30,29 @@ import (
 
 // NewMigrateCmd returns the migrate command
 func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.GetViper()
+	v := viper.New()
 	migrateCmd := &cobra.Command{
 		Use:          "migrate",
 		Short:        "Manage migrations on the database",
 		SilenceUsage: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			err := ec.Prepare()
+			if err != nil {
+				return err
+			}
+			err = ec.Validate()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
 	}
 	migrateCmd.AddCommand(
-		newMigrateApplyCmd(ec),
-		newMigrateStatusCmd(ec),
-		newMigrateCreateCmd(ec),
-		newMigrateSquashCmd(ec),
+		newMigrateApplyCmd(ec, v),
+		newMigrateStatusCmd(ec, v),
+		newMigrateCreateCmd(ec, v),
+		newMigrateSquashCmd(ec, v),
 	)
 	migrateCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
 	migrateCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -49,10 +49,10 @@ func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		},
 	}
 	migrateCmd.AddCommand(
-		newMigrateApplyCmd(ec, v),
-		newMigrateStatusCmd(ec, v),
-		newMigrateCreateCmd(ec, v),
-		newMigrateSquashCmd(ec, v),
+		newMigrateApplyCmd(ec),
+		newMigrateStatusCmd(ec),
+		newMigrateCreateCmd(ec),
+		newMigrateSquashCmd(ec),
 	)
 	migrateCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
 	migrateCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")

--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -8,10 +8,9 @@ import (
 	migrate "github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func newMigrateApplyCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
+func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 	opts := &MigrateApplyOptions{
 		EC: ec,
 	}

--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -8,11 +8,9 @@ import (
 	migrate "github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &MigrateApplyOptions{
 		EC: ec,
 	}
@@ -56,7 +54,6 @@ func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura migrate apply --down all`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -96,15 +93,6 @@ func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.BoolVar(&opts.SkipExecution, "skip-execution", false, "skip executing the migration action, but mark them as applied")
 	f.StringVar(&opts.MigrationType, "type", "up", "type of migration (up, down) to be used with version flag")
 
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 	return migrateApplyCmd
 }
 

--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -8,9 +8,10 @@ import (
 	migrate "github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
+func newMigrateApplyCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
 	opts := &MigrateApplyOptions{
 		EC: ec,
 	}

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/spf13/pflag"
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
@@ -26,7 +27,7 @@ const migrateCreateCmdExamples = `  # Setup migration files for the first time b
   # Setup migration files from an instance mentioned by the flag:
   hasura migrate create init --from-server --endpoint "<endpoint>"`
 
-func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
+func newMigrateCreateCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
 	opts := &migrateCreateOptions{
 		EC: ec,
 	}
@@ -38,13 +39,6 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		Example:      migrateCreateCmdExamples,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 			opts.EC.Spin("Creating migration files...")

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/spf13/pflag"
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
@@ -27,7 +26,7 @@ const migrateCreateCmdExamples = `  # Setup migration files for the first time b
   # Setup migration files from an instance mentioned by the flag:
   hasura migrate create init --from-server --endpoint "<endpoint>"`
 
-func newMigrateCreateCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
+func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 	opts := &migrateCreateOptions{
 		EC: ec,
 	}
@@ -65,7 +64,6 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Comman
 
 	migrateCreateCmd.MarkFlagFilename("sql-from-file")
 	migrateCreateCmd.MarkFlagFilename("metadata-from-file")
-
 
 	return migrateCreateCmd
 }

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
 	log "github.com/sirupsen/logrus"
@@ -28,7 +27,6 @@ const migrateCreateCmdExamples = `  # Setup migration files for the first time b
   hasura migrate create init --from-server --endpoint "<endpoint>"`
 
 func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &migrateCreateOptions{
 		EC: ec,
 	}
@@ -41,7 +39,6 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -71,18 +68,10 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.StringArrayVar(&opts.schemaNames, "schema", []string{"public"}, "name of Postgres schema to export as migration")
 	f.StringVar(&opts.metaDataFile, "metadata-from-file", "", "path to a hasura metadata file to be used for up actions")
 	f.BoolVar(&opts.metaDataServer, "metadata-from-server", false, "take metadata from the server and write it as an up migration file")
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
 
 	migrateCreateCmd.MarkFlagFilename("sql-from-file")
 	migrateCreateCmd.MarkFlagFilename("metadata-from-file")
 
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return migrateCreateCmd
 }

--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -12,13 +12,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
 )
 
-func newMigrateSquashCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
+func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
 	opts := &migrateSquashOptions{
 		EC: ec,
 	}
@@ -47,7 +45,6 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Comman
 
 	// mark flag as required
 	migrateSquashCmd.MarkFlagRequired("from")
-
 
 	return migrateSquashCmd
 }

--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -13,13 +13,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/spf13/viper"
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
 )
 
 func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &migrateSquashOptions{
 		EC: ec,
 	}
@@ -36,7 +34,6 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura migrate squash --name "<name>" --from 123`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -54,18 +51,9 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.StringVar(&opts.name, "name", "squashed", "name for the new squashed migration")
 	f.BoolVar(&opts.deleteSource, "delete-source", false, "delete the source files after squashing without any confirmation")
 
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
 	// mark flag as required
 	migrateSquashCmd.MarkFlagRequired("from")
 
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return migrateSquashCmd
 }

--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -12,12 +12,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
 )
 
-func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
+func newMigrateSquashCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
 	opts := &migrateSquashOptions{
 		EC: ec,
 	}
@@ -33,13 +34,6 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Add a name for the new squashed migration
   hasura migrate squash --name "<name>" --from 123`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.newVersion = getTime()
 			return opts.run()

--- a/cli/commands/migrate_status.go
+++ b/cli/commands/migrate_status.go
@@ -10,9 +10,10 @@ import (
 	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-func newMigrateStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
+func newMigrateStatusCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
 	opts := &MigrateStatusOptions{
 		EC: ec,
 	}
@@ -25,13 +26,6 @@ func newMigrateStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Check status on a different server:
   hasura migrate status --endpoint "<endpoint>"`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := ec.Prepare()
-			if err != nil {
-				return err
-			}
-			return ec.Validate()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.EC.Spin("Fetching migration status...")
 			status, err := opts.Run()

--- a/cli/commands/migrate_status.go
+++ b/cli/commands/migrate_status.go
@@ -10,10 +10,9 @@ import (
 	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func newMigrateStatusCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Command {
+func newMigrateStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
 	opts := &MigrateStatusOptions{
 		EC: ec,
 	}

--- a/cli/commands/migrate_status.go
+++ b/cli/commands/migrate_status.go
@@ -10,11 +10,9 @@ import (
 	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func newMigrateStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
-	v := viper.New()
 	opts := &MigrateStatusOptions{
 		EC: ec,
 	}
@@ -28,7 +26,6 @@ func newMigrateStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura migrate status --endpoint "<endpoint>"`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err
@@ -47,17 +44,6 @@ func newMigrateStatusCmd(ec *cli.ExecutionContext) *cobra.Command {
 			return nil
 		},
 	}
-
-	f := migrateStatusCmd.Flags()
-	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	f.String("access-key", "", "access key for Hasura GraphQL Engine")
-	f.MarkDeprecated("access-key", "use --admin-secret instead")
-
-	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
 
 	return migrateStatusCmd
 }


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Use global viper in actions subcommands. instead of duplicating subcommands use persistent flags. 

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)
