### PR TITLE
On v2 config don't generate yaml migration files

### DIFF
--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -122,7 +122,7 @@ func (o *ConsoleOptions) Run() error {
 		t,
 	}
 
-	r.setRoutes(o.EC.MigrationDir, o.EC.Logger)
+	r.setRoutes(o.EC.MigrationDir, o.EC.Logger, ec.Config.Version)
 
 	consoleTemplateVersion := o.EC.Version.GetConsoleTemplateVersion()
 	consoleAssetsVersion := o.EC.Version.GetConsoleAssetsVersion()
@@ -233,12 +233,13 @@ type cRouter struct {
 	migrate *migrate.Migrate
 }
 
-func (r *cRouter) setRoutes(migrationDir string, logger *logrus.Logger) {
+func (r *cRouter) setRoutes(migrationDir string, logger *logrus.Logger, configVersion cli.ConfigVersion) {
 	apis := r.router.Group("/apis")
 	{
 		apis.Use(setLogger(logger))
 		apis.Use(setFilePath(migrationDir))
 		apis.Use(setMigrate(r.migrate))
+		apis.Use(setConfigVersion(int(configVersion)))
 		// Migrate api endpoints and middleware
 		migrateAPIs := apis.Group("/migrate")
 		{
@@ -286,6 +287,13 @@ func setMetadataFile(file string) gin.HandlerFunc {
 func setLogger(logger *logrus.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Set("logger", logger)
+		c.Next()
+	}
+}
+
+func setConfigVersion(configVersion int) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("configVersion", configVersion)
 		c.Next()
 	}
 }

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -85,7 +85,7 @@ type migrateCreateOptions struct {
 
 func (o *migrateCreateOptions) run() (version int64, err error) {
 	timestamp := getTime()
-	createOptions := mig.New(timestamp, o.name, o.EC.MigrationDir)
+	createOptions := mig.New(timestamp, o.name, o.EC.MigrationDir, o.EC.Config.Version)
 
 	if o.fromServer {
 		o.sqlServer = true

--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -68,7 +68,7 @@ func (o *migrateSquashOptions) run() error {
 		return errors.Wrap(err, "unable to initialize migrations driver")
 	}
 
-	versions, err := mig.SquashCmd(migrateDrv, o.from, o.newVersion, o.name, o.EC.MigrationDir)
+	versions, err := mig.SquashCmd(migrateDrv, o.from, o.newVersion, o.name, o.EC.MigrationDir, o.EC.Config.Version)
 	o.EC.Spinner.Stop()
 	if err != nil {
 		return errors.Wrap(err, "unable to squash migrations")

--- a/cli/migrate/api/migrate.go
+++ b/cli/migrate/api/migrate.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/hasura/graphql-engine/cli/migrate/cmd"
 	"github.com/hasura/graphql-engine/cli/migrate/database/hasuradb"
@@ -42,6 +43,10 @@ type requestType struct {
 }
 
 func MigrateAPI(c *gin.Context) {
+	configVersion, ok := c.Get("configVersion")
+	if !ok {
+		return
+	}
 	migratePtr, ok := c.Get("migrate")
 	if !ok {
 		return
@@ -128,7 +133,7 @@ func MigrateAPI(c *gin.Context) {
 			}
 		}
 
-		createOptions := cmd.New(timestamp, request.Name, sourceURL.Path)
+		createOptions := cmd.New(timestamp, request.Name, sourceURL.Path, configVersion.(cli.ConfigVersion))
 		if sqlUp.String() != "" {
 			err := createOptions.SetSQLUp(sqlUp.String())
 			if err != nil {

--- a/cli/migrate/api/squash.go
+++ b/cli/migrate/api/squash.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/migrate"
 	"github.com/hasura/graphql-engine/cli/migrate/cmd"
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
@@ -32,6 +33,10 @@ func (s *squashCreateRequest) setDefaults() {
 }
 
 func SquashCreateAPI(c *gin.Context) {
+	configVersion, ok := c.Get("configVersion")
+	if !ok {
+		return
+	}
 	migratePtr, ok := c.Get("migrate")
 	if !ok {
 		return
@@ -58,7 +63,7 @@ func SquashCreateAPI(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
 		return
 	}
-	versions, err := cmd.SquashCmd(t, request.From, request.version, request.Name, sourceURL.Path)
+	versions, err := cmd.SquashCmd(t, request.From, request.version, request.Name, sourceURL.Path, configVersion.(cli.ConfigVersion))
 	if err != nil {
 		if strings.HasPrefix(err.Error(), DataAPIError) {
 			c.JSON(http.StatusBadRequest, &Response{Code: "data_api_error", Message: strings.TrimPrefix(err.Error(), DataAPIError)})


### PR DESCRIPTION
On running `hasura migrate create --from-server` don't generate yaml files if config us on V2
